### PR TITLE
the 'view on marvel.com' link works for each comic now, which is cool

### DIFF
--- a/app/controllers/comic-controller.js
+++ b/app/controllers/comic-controller.js
@@ -3,7 +3,7 @@
 angular.module('MarvelApp')
   .controller('ComicController', ['$scope', '$location', '$routeParams','MarvelComics',  function($scope, $location, $routeParams, MarvelComics){
     var controller = this;
-    var counter = 0;
+    var counter = 5;
 
     $scope.loadMore = function(){
       counter += 24;

--- a/app/views/comic/single.html
+++ b/app/views/comic/single.html
@@ -8,6 +8,7 @@
           </div>
           <div class="comic-info col-sm-9 col-md-9">
               <h2>{{comicCtrl.comic.title}}</h2>
+              <h4 ng-show='comicCtrl.comic.format.length > 0'>On Sale Date : {{comicCtrl.comic.dates[0].date | limitTo:10}}</h4>
               <h4 ng-show='comicCtrl.comic.format.length > 0'>Format : {{comicCtrl.comic.format}}</h4>
               <h4 ng-show='comicCtrl.comic.prices.length > 0'>Price : ${{comicCtrl.comic.prices[0].price}} USD</h4>
               <h4>Number of pages : {{comicCtrl.comic.pageCount}}</h4>


### PR DESCRIPTION
# Overview
  - This PR adds a feature where on the individual comic page now has a link at the bottom that opens a new window with the relevant Marvel.com page.

## Changed Content
  - Files Modified:
    - ```app/controllers/comic-controller.js```
    - ```app/views/comic/single.html```

## Completed/Still Needed
  - In Single Comic View, you can click on "View on Marvel.com" and it will direct to that comic's specific entry on Marvel.com.

## Documentation
  - None